### PR TITLE
Базовый интерфейс, полупереезд на FastAPI

### DIFF
--- a/flask/dependency.py
+++ b/flask/dependency.py
@@ -1,7 +1,6 @@
 """Module with dependencies of endpoints."""
 
 import os
-import uuid
 
 from fastapi import Request
 from redis import Redis
@@ -11,29 +10,31 @@ from spotipy.oauth2 import SpotifyOAuth
 
 from exceptions import UnknownCookieException
 
+DEFAULT_USER_TOKEN_COOKIE = "playlist_selection_user_id"
 
 class SpotifyAuth:
     """Dependency from authorization in Spotify."""
     
-    def __init__(self, redis_db: Redis):
+    def __init__(self, redis_db: Redis):  # noqa: D417
         """Contstructor of dependency.
         
         Keyword Arguments:
-        redis_db -- Redis object of cached tokens database
+        redis_db -- Redis object of cached tokens database.
         """
         self._redis_db = redis_db
     
-    def __call__(self, request: Request) -> SpotifyOAuth:
+    def __call__(self, request: Request) -> SpotifyOAuth:  # noqa: D417
         """Call method of dependency.
 
         Keyword Arguments:
-        request -- Request - user request to endpoint
+        request -- Request - user request to endpoint.
         """
-        if "session_uuid" not in request.session.keys():
-            # TODO: update with cookie
-            request.session["session_uuid"] = str(uuid.uuid4())
+        user_token_cookie = request.cookies.get(DEFAULT_USER_TOKEN_COOKIE)
+        if user_token_cookie is None:
+            raise UnknownCookieException(url="AAA")
 
-        cache_handler = RedisCacheHandler(self._redis_db, key=request.session["session_uuid"])
+        cache_handler = RedisCacheHandler(self._redis_db, key=user_token_cookie)
+
         # TODO: move secrets to config?
         sp_oauth = SpotifyOAuth(
             client_id=os.environ["PLAYLIST_SELECTION_CLIENT_ID"],

--- a/flask/templates/base.html
+++ b/flask/templates/base.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>PlaylistSelection</title>
     <!-- Link to your CSS file -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='style.css') }}">
 </head>
 <body>
     <header class="navbar">
@@ -12,7 +12,7 @@
             <h1>PlaylistSelection</h1>
         </div>
         <div class="login-section">
-            {% if session.get('token_info') %}
+            {% if request.cookies.get('playlist_selection_user_id_valid') %}
                 <a href="{{ url_for('logout') }}">Logout</a>
             {% else %}
                 <a href="{{ url_for('login') }}">Login with Spotify</a>
@@ -21,8 +21,6 @@
     </header>
 
     <main>
-        <!-- Extract info about current user -->
-        {% set current_user = session.get('current_user') %}
         <!-- Main content goes here -->
         {% block content %}
         {% endblock %}


### PR DESCRIPTION
* добавил базовый интерфейс и заготовку под генерацию плейлистов;
* переписал на fastapi (оставил flask тоже - можно подумать).

Работает так (с оформлением пока максимально не упарывался):

раз
![изображение](https://github.com/slavkostrov/playlist_selection/assets/64536258/066d5419-fc31-40d7-82ef-a982dedc05b0)

два 
![изображение](https://github.com/slavkostrov/playlist_selection/assets/64536258/e77b3f8f-2f9a-4bf5-afa5-b62b814ce131)

три
![изображение](https://github.com/slavkostrov/playlist_selection/assets/64536258/326192ee-05a5-4bcb-a9fa-940bf0b4c882)

четыре
![изображение](https://github.com/slavkostrov/playlist_selection/assets/64536258/3e8f9481-77bd-413b-8390-44c8b1f021ec)

пять
![изображение](https://github.com/slavkostrov/playlist_selection/assets/64536258/002a92c2-effe-43a6-8f45-fc133c33cc2c)

шесть
![изображение](https://github.com/slavkostrov/playlist_selection/assets/64536258/56aabfbd-4da8-4045-85b8-cca49efba799)


