### PR TITLE
[hotfix] metrics

### DIFF
--- a/playlist_selection/metrics/metrics.py
+++ b/playlist_selection/metrics/metrics.py
@@ -235,7 +235,7 @@ class SoundParametersDiff(BasicMetric):
         def l2_norm(first, second):
             first, second = np.array(first), np.array(second)
             diff = np.abs(first - second) / np.abs(np.maximum(first, second))
-            return np.sqrt(np.square(diff).sum()).mean()
+            return np.sqrt(np.nansum(np.square(diff))).mean()
 
         sound_diff = [
             [l2_norm(true_genres, pred_genres) for pred_genres in pred_genres_lst]

--- a/playlist_selection/metrics/utils.py
+++ b/playlist_selection/metrics/utils.py
@@ -5,22 +5,28 @@ import pandas as pd
 
 
 def prepare_for_metric(
-    df: pd.DataFrame,
+    train_df: pd.DataFrame,
+    predict_df: pd.DataFrame,
+    predicted_indexes: np.array,
     columns: list[str] | str,
-    neighbors_indexes: np.array,
+    k_neighbors: int = 3,
 ) -> tuple[np.array, np.array]:
     """Prepare data for metrics evaluation.
 
     Args:
-        df: DataFrame to take data from
+        train_df: train dataFrame to take true features from
+        predict_df: predict dataFrame to take pred features from
+        predicted_indexes: indexes to take after model inference (flatten array)
         columns: features to take from dataframe
-        neighbors_indexes: indexes to take after model inference
+        k_neighbors: number of predictions for each input track
 
     Returns:
         Tuple of (y_true, y_pred) objects in metric's format
     """
-    y_true = df[columns].to_numpy()
-    y_pred = np.take(y_true, neighbors_indexes, axis=0)
+    neighbors_indexes = np.array(predicted_indexes).reshape(-1, k_neighbors)
+    y_true = predict_df[columns].to_numpy()
+    y_pred = train_df[columns].to_numpy()
+    y_pred = np.take(y_pred, neighbors_indexes, axis=0)
 
     if y_pred.shape[-1] == 1:
         y_pred = y_pred.reshape(*y_pred.shape[:-1])


### PR DESCRIPTION
Теперь на вход в `prepare_for_metrics` прилетают:

1. Трейн датафрейм (оттуда берем y_pred фичи)
2. Предикт датафрейм (оттуда берем y_true фичи)
3. Индексы во flatten виде, как и отдает модель. То есть делаем backward_mapping и суем в функцию
4. Фичи по которым считаем метрику
5. Количество предиктов для каждого трека

Небольшой апдейт `SoundParametersDIff` связан с тем, что наткнулся с ситуацией когда обе фичи были равны 0, следовательно 0 / max(0, 0) = nan